### PR TITLE
Add setup script for initial environment configuration

### DIFF
--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Install PostgreSQL
+sudo apt-get update
+sudo apt-get install -y postgresql postgresql-contrib
+
+# Configure PostgreSQL
+sudo -u postgres psql -c "CREATE DATABASE attendancedb;"
+sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres';"
+
+# Create .env file
+cp backend/.env.example backend/.env
+
+# Build and run the application
+make build


### PR DESCRIPTION
This PR adds a setup.sh script that automates the initial environment setup as described in .openhands/setup.md